### PR TITLE
Fix default config.mak to not break MSVC builds

### DIFF
--- a/etc/profile.d/git-sdk.sh
+++ b/etc/profile.d/git-sdk.sh
@@ -113,7 +113,9 @@ sdk () {
 		if test git = "$2" && test ! -f "$src_dir/config.mak"
 		then
 			cat >"$src_dir/config.mak" <<-\EOF
+			ifndef MSVC
 			DEVELOPER=1
+			endif
 			ifndef NDEBUG
 			CFLAGS := $(filter-out -O2,$(CFLAGS))
 			ASLR_OPTION := -Wl,--dynamicbase


### PR DESCRIPTION
The default config.mak file that is generated by "sdk init git" always
sets DEVELOPER=1, which breaks MSVC builds.

This change is to modify the default config.mak file that is generated
by "sdk init git" to not set "DEVELOPER=1" for MSVC builds.

Signed-off-by: Jameson Miller <jamill@microsoft.com>