### PR TITLE
Add a GitHub Action to generate and upload some artifacts to Azure Blobs

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -53,13 +53,13 @@ jobs:
           name: minimal-sdk
           path: git-sdk-64-minimal.tar.xz
       - name: clone git.git's `master`
-        run: git clone --depth=1 --branch master https://github.com/git/git git
+        run: git clone --depth=1 --branch master https://github.com/git/git ..\git
       - name: build current `master` of git.git
         run: |
-          & .\minimal-sdk\usr\bin\bash.exe -lc "make -C git NO_PERL=1 -j8 all strip"
+          & .\minimal-sdk\usr\bin\bash.exe -lc "make -C ../git NO_PERL=1 -j8 all strip"
       - name: compress git artifacts
         shell: bash
-        run: tar cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
+        run: tar -C .. -cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
       - name: upload git artifacts for testing
         uses: actions/upload-artifact@v1
         with:
@@ -87,11 +87,11 @@ jobs:
           path: ${{github.workspace}}
       - name: uncompress git-artifacts
         shell: bash
-        run: tar xJf git-artifacts.tar.xz
+        run: tar -C .. -xJf git-artifacts.tar.xz
       - name: test
         run: |
           & .\minimal-sdk\usr\bin\bash.exe -lc @"
-            cd git/t &&
+            cd ../git/t &&
             make T=\"`$(ls -S t[0-9]*.sh | awk \"!((NR+${{matrix.nr}})%17)\" | tr '\n' \\ )\" prove || {
               for d in trash*
               do

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -34,3 +34,92 @@ jobs:
           name: .
           path: ${{env.ARTIFACT_PATH}}
           container: ci-artifacts
+  minimal-sdk-artifact:
+    runs-on: windows-latest
+    steps:
+      - name: clone git-sdk-64
+        run: git clone --bare --depth=1 --single-branch -b master https://github.com/git-for-windows/git-sdk-64
+      - name: clone build-extra
+        run: git clone --depth=1 --single-branch -b master https://github.com/git-for-windows/build-extra
+      - name: build git-sdk-64-minimal-sdk
+        shell: bash
+        run: sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git minimal-sdk
+      - name: compress artifact
+        shell: bash
+        run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-64-minimal.tar.xz
+      - name: upload minimal-sdk artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: minimal-sdk
+          path: git-sdk-64-minimal.tar.xz
+      - name: clone git.git's `master`
+        run: git clone --depth=1 --branch master https://github.com/git/git git
+      - name: build current `master` of git.git
+        run: |
+          & .\minimal-sdk\usr\bin\bash.exe -lc "make -C git NO_PERL=1 -j8 all strip"
+      - name: compress git artifacts
+        shell: bash
+        run: tar cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
+      - name: upload git artifacts for testing
+        uses: actions/upload-artifact@v1
+        with:
+          name: git-artifacts
+          path: git-artifacts.tar.xz
+  test-minimal-sdk:
+    runs-on: windows-latest
+    needs: [minimal-sdk-artifact]
+    strategy:
+      matrix:
+        nr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    steps:
+      - name: download minimal-sdk artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: minimal-sdk
+          path: ${{github.workspace}}
+      - name: uncompress minimal-sdk
+        shell: bash
+        run: mkdir -p minimal-sdk && tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz
+      - name: download git artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: git-artifacts
+          path: ${{github.workspace}}
+      - name: uncompress git-artifacts
+        shell: bash
+        run: tar xJf git-artifacts.tar.xz
+      - name: test
+        run: |
+          & .\minimal-sdk\usr\bin\bash.exe -lc @"
+            cd git/t &&
+            make T=\"`$(ls -S t[0-9]*.sh | awk \"!((NR+${{matrix.nr}})%17)\" | tr '\n' \\ )\" prove || {
+              for d in trash*
+              do
+                t=`${d#trash directory.}
+                echo ===========================
+                echo Failed: `$t.sh
+                cat test-results/`$t.out
+              done
+              exit 1
+            }
+          "@
+        env:
+          GIT_TEST_OPTS: --verbose-log -x --no-chain-lint
+          GIT_PROVE_OPTS: --timer --jobs 8
+          NO_SVN_TESTS: 1
+  upload-minimal-sdk:
+    runs-on: windows-latest
+    needs: [test-minimal-sdk]
+    steps:
+      - name: download minimal-sdk artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: minimal-sdk
+          path: ${{github.workspace}}
+      - name: upload to Azure Blobs
+        uses: fixpoint/azblob-upload-artifact@v3
+        with:
+          connection-string: ${{secrets.CI_ARTIFACTS_CONNECTION_STRING}}
+          name: .
+          path: git-sdk-64-minimal.tar.xz
+          container: ci-artifacts

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -1,0 +1,36 @@
+name: ci-artifacts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  ci-artifact:
+    strategy:
+      matrix:
+        artifact: [full-sdk, build-installers, makepkg-git]
+    runs-on: windows-latest
+    steps:
+      - name: clone git-sdk-64
+        run: git clone --bare --depth=1 --single-branch -b master https://github.com/git-for-windows/git-sdk-64
+      - name: clone build-extra
+        run: git clone --depth=1 --single-branch -b master https://github.com/git-for-windows/build-extra
+      - name: build git-sdk-64-${{matrix.artifact}}
+        shell: bash
+        run: |
+          sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git ${{matrix.artifact}}
+          echo "::set-env name=ARTIFACT_PATH::$(echo ${{matrix.artifact}}/*.tar.xz)"
+      - name: compress artifact
+        if: matrix.artifact != 'full-sdk'
+        shell: bash
+        run: |
+          (cd ${{matrix.artifact}} && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-64-${{matrix.artifact}}.tar.xz
+          echo "::set-env name=ARTIFACT_PATH::$(echo *.tar.xz)"
+      - name: upload to Azure Blobs
+        uses: fixpoint/azblob-upload-artifact@v3
+        with:
+          connection-string: ${{secrets.CI_ARTIFACTS_CONNECTION_STRING}}
+          name: .
+          path: ${{env.ARTIFACT_PATH}}
+          container: ci-artifacts

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   ci-artifact:
+    if: github.event.repository.fork == false
     strategy:
       matrix:
         artifact: [full-sdk, build-installers, makepkg-git]
@@ -35,6 +36,7 @@ jobs:
           path: ${{env.ARTIFACT_PATH}}
           container: ci-artifacts
   minimal-sdk-artifact:
+    if: github.event.repository.fork == false
     runs-on: windows-latest
     steps:
       - name: clone git-sdk-64

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -70,7 +70,8 @@ jobs:
     needs: [minimal-sdk-artifact]
     strategy:
       matrix:
-        nr: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        # 0..16 permutated according to the matrix builds' runtimes as of git/git@9fadedd63
+        nr: [9, 6, 13, 0, 8, 5, 2, 16, 15, 11, 10, 1, 7, 3, 14, 12, 4]
     steps:
       - name: download minimal-sdk artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
In the [upcoming GitHub Action for git.git](https://github.com/git/git/pull/743), we need to have a very fast way to initialize a subset of Git for Windows' SDK that can build Git and run its test suite.

In the Azure Pipeline which we currently use in git.git, we do that by downloading the build artifact of _another_ Azure Pipeline. But this is not an option here, as the `Download build artifact` step is an _Azure Pipelines_ task, and it is only able to access builds within the same Azure DevOps org. Neither is the case for GitHub Actions.

To address that, we came up with the solution to add a Bash step (that is executed using the Git for Windows version installed on the build agents, which comes with all the building blocks we need for this solution): download the artifact as a `.tar.xz` file from Azure Blobs (which is reasonably small at ~30MB to be _super_ fast), pipe the output to `tar` (using `xz` to decompress). This typically takes around 7 seconds altogether.

This PR adds a GitHub Action to git-sdk-64 so that this artifact is generated and uploaded whenever git-sdk-64's `master` changes.

In addition to that artifact (which we call `git-sdk-64-minimal`), we generate and upload three more artifacts that are used to generate the Pacman package `mingw-w64-git`, the official installers/portable Gits/MinGits, and finally an artifact (called `git-sdk-64-full-sdk`) for building arbitrary Pacman packages.