### PR TITLE
ci: assorted validations of the `minimal-sdk` artifact

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -87,3 +87,30 @@ jobs:
           GIT_TEST_OPTS: --verbose-log -x --no-chain-lint
           GIT_PROVE_OPTS: --timer --jobs 8
           NO_SVN_TESTS: 1
+  assorted-validations:
+    runs-on: windows-latest
+    needs: [minimal-sdk-artifact]
+    steps:
+      - name: download minimal-sdk artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: minimal-sdk
+          path: ${{github.workspace}}
+      - name: uncompress minimal-sdk
+        shell: bash
+        run: mkdir -p minimal-sdk && tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz
+      - name: run some tests
+        shell: bash
+        env:
+          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
+        run: |
+          set -x
+          cat >dll.c <<-\EOF &&
+          __attribute__((dllexport)) int increment(int i)
+          {
+              return i + 1;
+          }
+          EOF
+
+          gcc -Wall -g -O2 -shared -o sample.dll dll.c
+          ls -la

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -87,23 +87,3 @@ jobs:
           GIT_TEST_OPTS: --verbose-log -x --no-chain-lint
           GIT_PROVE_OPTS: --timer --jobs 8
           NO_SVN_TESTS: 1
-  upload-minimal-sdk:
-    if: github.event.repository.fork == false
-    runs-on: windows-latest
-    needs: [test-minimal-sdk]
-    steps:
-      - name: download minimal-sdk artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: minimal-sdk
-          path: ${{github.workspace}}
-      - name: rename the artifact
-        shell: bash
-        run: mv git-sdk-64-minimal.tar.xz git-sdk-64-minimal-test.tar.xz
-      - name: upload to Azure Blobs
-        uses: fixpoint/azblob-upload-artifact@v3
-        with:
-          connection-string: ${{secrets.CI_ARTIFACTS_CONNECTION_STRING}}
-          name: .
-          path: git-sdk-64-minimal-test.tar.xz
-          container: ci-artifacts


### PR DESCRIPTION
This aligns the `ci-artifacts` GitHub workflow with what [the `git-sdk-64-minimal` Azure Pipeline](https://dev.azure.com/Git-for-Windows/git/_build?definitionId=22&_a=summary) does: it verifies not only that the current git/git can be built and passes the test suite successfully, it also verifies that expectations by other consumers (like `rainers/cv2pdb`) are met.