### PR TITLE
makepkg-git-i686: include libisl

### DIFF
--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -9,6 +9,7 @@
 /mingw32/bin/ld.exe
 /mingw32/bin/libgcc*.dll
 /mingw32/bin/libgmp-*[0-9].dll
+/mingw32/bin/libisl-*[0-9].dll
 /mingw32/bin/libwinpthread-*[0-9].dll
 /mingw32/bin/libzstd.dll
 /mingw32/bin/zlib*[0-9].dll


### PR DESCRIPTION
As of mingw-w64-i686-gcc 12.1.0-3, `cc1.exe` depends on `libisl-23.dll`.

In 44042507c40 (minimal-sdk: include libisl, 2022-07-06),  we already included this in the `minimal-sdk` build, to fix the regular CI/PR builds of Git and Git for Windows, and now we also include it in the `makepkg-git-i686` sparse checkout, to fix building 32-bit Git for Windows.