### PR TITLE
ci: verify that the Git and Scalar executables work in Nano Server

### DIFF
--- a/.github/workflows/nano-server.yml
+++ b/.github/workflows/nano-server.yml
@@ -1,0 +1,35 @@
+name: Windows Nano Server tests
+
+on: [workflow_dispatch, push]
+
+jobs:
+  test-nano-server:
+    if: github.event.repository.fork == false || github.event_name == 'workflow_dispatch'
+    runs-on: windows-2022
+    env:
+      REF: ${{github.ref}}
+      WINDBG_DIR: "C:/Program Files (x86)/Windows Kits/10/Debuggers/x64"
+      IMAGE: mcr.microsoft.com/powershell:nanoserver-ltsc2022
+
+    steps:
+      - name: partial clone
+        shell: bash
+        run: |
+          # cannot use `git clone` directly, to allow for PR's refs to be fetched
+          git clone --no-checkout --single-branch -b ${REF#refs/heads/} --filter=blob:none --depth=1 \
+            https://github.com/${{github.repository}} . &&
+          git sparse-checkout set .github/workflows mingw64/bin &&
+          git checkout HEAD
+      - name: pull nanoserver image
+        shell: bash
+        run: docker pull $IMAGE
+      - name: run nano-server test
+        shell: bash
+        run: |
+          docker pull $IMAGE
+          docker run \
+            --user "ContainerAdministrator" \
+            -v "$WINDBG_DIR:C:/dbg" \
+            -v "$(cygpath -aw mingw64/bin):C:/test" \
+            -v "$(cygpath -aw .github/workflows/nano-server):C:/script" \
+            $IMAGE pwsh.exe C:/script/run-tests.ps1

--- a/.github/workflows/nano-server/run-tests.ps1
+++ b/.github/workflows/nano-server/run-tests.ps1
@@ -1,0 +1,34 @@
+# Each exectuable to test is run with the `version` subcommand; It is
+# expected to return with exit code 0.
+
+$executables_to_test = @(
+    'C:\test\git.exe',
+    'C:\test\scalar.exe'
+)
+
+foreach ($executable in $executables_to_test)
+{
+    Write-Output "Now testing $($executable)"
+    &$executable 'version'
+    if ($LASTEXITCODE -ne 0) {
+	# If the command failed, run the debugger to find out what function or
+	# DLL could not be found and then exit the script with failure. The
+	# missing DLL or EXE will be referenced near the end of the output
+
+        # Set flag to ask the debugger to
+	# - show loader stub dianostics,
+	# - enable system critical breaks,
+	# - stop on exception, and
+	# - stop on unhandled user-mode exception
+	#
+	# For further details, see
+	# https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/gflags-flag-table
+        C:\dbg\gflags -i $executable +SLS +SCB +SOE +SUE
+
+        C:\dbg\cdb.exe -c "g" -c "q" $executable 'version'
+
+        exit 1
+    }
+}
+
+exit 0


### PR DESCRIPTION
It was reported in https://github.com/git-for-windows/git/issues/4052 that Git for Windows v2.38.0 introduced a regression (fixed in https://github.com/git-for-windows/git/pull/4074) where `git.exe` could no longer be run in [Nano Server containers](https://hub.docker.com/_/microsoft-windows-nanoserver).

Let's add a workflow that verifies that Git for Windows does not regress on this in the future.

The CI run will necessarily fail at the moment, as Git for Windows v2.38.1 was released without any fix for Nano Server, and will print helpful information as to any missing symbol, as demonstrated by [this run](https://github.com/dscho/git-sdk-64/actions/runs/3381216897/jobs/5614881763#step:4:1259).

As demonstrated by [this run](https://github.com/dscho/git-sdk-64/actions/runs/3381201988) (which uses the artifacts produced by a build of the PullRequest that fixes the issue), the CI run will start succeeding once we build a new Git version after merging said PR.