### PR TITLE
Fix the `ci-artifacts` runs

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -49,7 +49,7 @@ jobs:
     needs: [minimal-sdk-artifact]
     strategy:
       matrix:
-        # 0..16 permutated according to the matrix builds' runtimes as of git/git@9fadedd63
+        # 0..16 permuted according to the matrix builds' timings as of git/git@9fadedd63
         nr: [9, 6, 13, 0, 8, 5, 2, 16, 15, 11, 10, 1, 7, 3, 14, 12, 4]
     steps:
       - name: download minimal-sdk artifact

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -14,10 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: clone git-sdk-64
-        shell: bash
-        run: git clone --bare --depth=1 --filter=blob:none --single-branch -b ${REF#refs/heads/} https://github.com/${{github.repository}}
-        env:
-          REF: ${{github.ref}}
+        run: git clone --bare --depth=1 --filter=blob:none --single-branch -b ${{github.ref_name}} https://github.com/${{github.repository}}
       - name: clone build-extra
         run: git clone --depth=1 --single-branch -b main https://github.com/git-for-windows/build-extra
       - name: build git-sdk-64-minimal-sdk

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-64-minimal.tar.xz
       - name: upload minimal-sdk artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: minimal-sdk
           path: git-sdk-64-minimal.tar.xz
@@ -53,7 +53,7 @@ jobs:
         shell: bash
         run: tar -C .. -czf git-artifacts.tar.gz --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git
       - name: upload git artifacts for testing
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: git-artifacts
           path: git-artifacts.tar.gz
@@ -66,7 +66,7 @@ jobs:
         nr: [9, 6, 13, 0, 8, 5, 2, 16, 15, 11, 10, 1, 7, 3, 14, 12, 4]
     steps:
       - name: download minimal-sdk artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: minimal-sdk
           path: ${{github.workspace}}
@@ -77,7 +77,7 @@ jobs:
           tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz &&
           minimal-sdk/init.sh
       - name: download git artifacts
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: git-artifacts
           path: ${{github.workspace}}
@@ -110,7 +110,7 @@ jobs:
     needs: [minimal-sdk-artifact]
     steps:
       - name: download minimal-sdk artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: minimal-sdk
           path: ${{github.workspace}}

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -44,7 +44,11 @@ jobs:
         shell: bash
         env:
           PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
-        run: make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
+        run: |
+          set -x
+          test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
+          test "$(type -p gcc)" = "/mingw64/bin/gcc" || exit 1
+          make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
       - name: compress git artifacts
         shell: bash
         run: tar -C .. -cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
@@ -83,6 +87,8 @@ jobs:
       - name: test
         shell: bash
         run: |
+          set -x
+          test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
           cd ../git/t &&
           make T="$(ls -S t[0-9]*.sh | awk '!((NR+${{matrix.nr}})%17)' | tr '\n' \ )" prove || {
             for d in trash*
@@ -120,6 +126,8 @@ jobs:
           PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
         run: |
           set -x
+          test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
+          test "$(type -p gcc)" = "/mingw64/bin/gcc" || exit 1
           cat >dll.c <<-\EOF &&
           __attribute__((dllexport)) int increment(int i)
           {

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -19,7 +19,17 @@ jobs:
         run: git clone --depth=1 --single-branch -b main https://github.com/git-for-windows/build-extra
       - name: build git-sdk-64-minimal-sdk
         shell: bash
-        run: sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git minimal-sdk
+        run: |
+          sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git minimal-sdk &&
+          cat <<-\EOF >minimal-sdk/init.sh &&
+          echo MSYSTEM=MINGW64 >>$GITHUB_ENV &&
+          cd "$(dirname "$0")" &&
+          cygpath -aw usr/bin/core_perl >>$GITHUB_PATH &&
+          cygpath -aw usr/bin >>$GITHUB_PATH &&
+          cygpath -aw mingw64/bin >>$GITHUB_PATH ||
+          exit 1
+          EOF
+          minimal-sdk/init.sh
       - name: compress artifact
         shell: bash
         run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-64-minimal.tar.xz
@@ -31,8 +41,10 @@ jobs:
       - name: clone git.git's `master`
         run: git clone --depth=1 --branch master https://github.com/git/git ..\git
       - name: build current `master` of git.git
-        run: |
-          & .\minimal-sdk\usr\bin\bash.exe -lc "make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip"
+        shell: bash
+        env:
+          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
+        run: make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
       - name: compress git artifacts
         shell: bash
         run: tar -C .. -cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
@@ -56,7 +68,10 @@ jobs:
           path: ${{github.workspace}}
       - name: uncompress minimal-sdk
         shell: bash
-        run: mkdir -p minimal-sdk && tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz
+        run: |
+          mkdir -p minimal-sdk &&
+          tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz &&
+          minimal-sdk/init.sh
       - name: download git artifacts
         uses: actions/download-artifact@v1
         with:
@@ -66,21 +81,21 @@ jobs:
         shell: bash
         run: tar -C .. -xJf git-artifacts.tar.xz
       - name: test
+        shell: bash
         run: |
-          & .\minimal-sdk\usr\bin\bash.exe -lc @"
-            cd ../git/t &&
-            make T=\"`$(ls -S t[0-9]*.sh | awk \"!((NR+${{matrix.nr}})%17)\" | tr '\n' \\ )\" prove || {
-              for d in trash*
-              do
-                t=`${d#trash directory.}
-                echo ===========================
-                echo Failed: `$t.sh
-                cat test-results/`$t.out
-              done
-              exit 1
-            }
-          "@
+          cd ../git/t &&
+          make T="$(ls -S t[0-9]*.sh | awk '!((NR+${{matrix.nr}})%17)' | tr '\n' \ )" prove || {
+            for d in trash*
+            do
+              t=${d#trash directory.}
+              echo ===========================
+              echo Failed: $t.sh
+              cat test-results/$t.out
+            done
+            exit 1
+          }
         env:
+          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;${{github.workspace}}\minimal-sdk\usr\bin\core_perl;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
           GIT_TEST_OPTS: --verbose-log -x --no-chain-lint
           GIT_PROVE_OPTS: --timer --jobs 8
           NO_SVN_TESTS: 1
@@ -95,7 +110,10 @@ jobs:
           path: ${{github.workspace}}
       - name: uncompress minimal-sdk
         shell: bash
-        run: mkdir -p minimal-sdk && tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz
+        run: |
+          mkdir -p minimal-sdk &&
+          tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz &&
+          minimal-sdk/init.sh
       - name: run some tests
         shell: bash
         env:

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -51,12 +51,12 @@ jobs:
           make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
       - name: compress git artifacts
         shell: bash
-        run: tar -C .. -cf - --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git | xz -9 >git-artifacts.tar.xz
+        run: tar -C .. -czf git-artifacts.tar.gz --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git
       - name: upload git artifacts for testing
         uses: actions/upload-artifact@v1
         with:
           name: git-artifacts
-          path: git-artifacts.tar.xz
+          path: git-artifacts.tar.gz
   test-minimal-sdk:
     runs-on: windows-latest
     needs: [minimal-sdk-artifact]
@@ -83,7 +83,7 @@ jobs:
           path: ${{github.workspace}}
       - name: uncompress git-artifacts
         shell: bash
-        run: tar -C .. -xJf git-artifacts.tar.xz
+        run: tar -C .. -xzf git-artifacts.tar.gz
       - name: test
         shell: bash
         run: |


### PR DESCRIPTION
This workflow is incredibly important because [the `setup-git-for-windows-sdk` Action](https://github.com/git-for-windows/setup-git-for-windows-sdk/) that is used over twenty times in every single Git CI run looks for the latest successful `ci-artifacts` run to determine from which git-sdk-64 commit to build the minimal SDK.

Some time yesterday, those `ci-artifacts` runs started failing, but not because of any change in git-sdk-64. The current best bet is that the underlying reason for those breakages is that PowerShell was upgraded from v7.2.7 to v7.3.0 on the GitHub build agents we use, and that PowerShell version (inadvertently?) changed some quoting/escaping rules. The [release notes for PowerShell v7.3.0](https://github.com/PowerShell/PowerShell/releases/tag/v7.3.0) (see also [here](https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-73?view=powershell-7.3)) do not seem to contain any smoking gun, but it is still the most probable explanation.

This here PR sidesteps that by moving away from PowerShell steps (and possibly fixing an unrelated issue where we _might_ have tested the wrong `gcc` in `assorted-validations`). For more details, see the commit message of 0739bb18deb55545fc274afd908175a80c750e46

Naturally, the `ci-artifacts` workflow does not run for PRs nor in forks, therefore I added two throw-away commits on top to trigger [this run](https://github.com/dscho/git-sdk-64/actions/runs/3481226868/jobs/5822206417) to demonstrate that this PR actually fixes the build.