### PR TITLE
Fix i686 git builds

### DIFF
--- a/.github/workflows/git-artifacts.yml
+++ b/.github/workflows/git-artifacts.yml
@@ -113,6 +113,19 @@ jobs:
           cp PKGBUILD.$version PKGBUILD &&
           git commit -s -m "mingw-w64-git: new version ($version)" PKGBUILD &&
           git bundle create "$b"/MINGW-packages.bundle origin/main..main)
+      - name: Build mingw-w64-i686-git
+        if: env.ARCH_NAME == 'x86_64'
+        shell: bash
+        run: |
+          set -x
+
+          # Make sure that there is a `/usr/bin/git` that can be used by `makepkg-mingw`
+          printf '#!/bin/sh\n\nexec /mingw${{env.ARCH_BITNESS}}/bin/git.exe "$@"\n' >/usr/bin/git &&
+
+          # Restrict `PATH` to MSYS2
+          PATH="/mingw${{env.ARCH_BITNESS}}/bin:/usr/bin:/C/Windows/system32"
+
+          sh -x /usr/src/build-extra/please.sh build-mingw-w64-git --only-32-bit -o artifacts HEAD
       - name: Publish mingw-w64-${{env.ARCH_NAME}}-git
         uses: actions/upload-artifact@v3
         with:

--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -10,6 +10,8 @@
 /mingw32/bin/libgcc*.dll
 /mingw32/bin/libgmp-*[0-9].dll
 /mingw32/bin/libisl-*[0-9].dll
+/mingw32/bin/libmpc-*[0-9].dll
+/mingw32/bin/libmpfr-*[0-9].dll
 /mingw32/bin/libwinpthread-*[0-9].dll
 /mingw32/bin/libzstd.dll
 /mingw32/bin/zlib*[0-9].dll


### PR DESCRIPTION
In 9902929964, we fixed building x86_64 Git. But since we use the x86_64 variant of Git for Windows' SDK to build the i686 flavors of `git.exe`, we would have need to mirror this fix also into `makepkg-git-i686`. Since we did not, the [most recent snapshot build failed](https://dev.azure.com/git-for-windows/git/_build/results?buildId=111948&view=logs&j=22d2a912-b8ea-58db-d228-19d0d4b7b005&t=8b46901d-9973-586a-215d-f651640d394e&l=209).

Let's fix this, and also adjust the `git-artifacts` workflow run to notify us of similar breakages in the future, well in advance of it becoming a problem.