### PR TITLE
sync: decouple from the `build-extra` repository

### DIFF
--- a/.github/commit-sdk.sh
+++ b/.github/commit-sdk.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# To help Continuous Integration, this script commits the files installed via
+# MSYS2 packages into the Git for Windows SDK.
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+summarize_commit () {
+	test $# -le 1 ||
+	die "summarize_commit: too many arguments ($*)"
+
+	if test -z "$1"
+	then
+		git diff --cached -M50 --raw -- var/lib/pacman/local/\*/desc
+	else
+		git show "$1" --format=%H \
+			-M15 --raw -- var/lib/pacman/local/\*/desc
+	fi |
+	sed -ne '/.* M\tvar\/lib\/pacman\/local\/\(mingw-w64-.*-\)\?git-extra-[1-9].*\/desc$/d' \
+	 -e '/ R[0-9]*\t/{s/-\([0-9]\)/ (\1/;h;s|-\([0-9][^/]*\)/desc$|\t\1)|;s|.*\t| -> |;x;s|/desc\t.*||;s|.*\t[^\t]*/||;G;s|\n||g;p}' \
+	 -e '/ A\t/{s|.*local/\([^/]*\)/desc|\1|;s|-\([0-9].*\)| (new: \1)|p}' \
+	 -e '/ D\t/{s|.*local/\([^/]*\)/desc|\1|;s|-\([0-9].*\)| (removed)|p}'
+}
+
+git add -A . &&
+if git diff-index --exit-code --cached HEAD -- \
+	':(exclude)var/lib/pacman/sync/' \
+	':(exclude)var/lib/pacman/local/git-extra-*/desc' \
+	':(exclude)var/lib/pacman/local/mingw-w64-*-git-extra-*/desc' \
+	':(exclude)etc/rebase.db*'
+then
+	# No changes, really, except maybe a new Pacman db
+	exit 0
+fi
+
+summary="$(summarize_commit)"
+count=$(echo "$summary" | wc -l) &&
+if test $count -lt 2
+then
+	oneline="Update $count package"
+else
+	oneline="Update $count packages"
+fi &&
+git commit -q -s -m "$oneline" -m "$summary" ||
+die "Could not commit changes"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,11 +12,11 @@ on:
 env:
   GIT_CONFIG_PARAMETERS: "'user.name=Git for Windows Build Agent' 'user.email=ci@git-for-windows.build' 'windows.sdk64.path=${{ github.workspace }}' 'windows.sdk32.path=' 'http.sslbackend=schannel' 'core.autocrlf=false' 'checkout.workers=16'"
   HOME: "${{ github.workspace }}\\home\\git-ci"
-  MSYSTEM: MINGW64
+  MSYSTEM: MSYS
 
 jobs:
   sync:
-    if: github.event.repository.fork == false || github.event.inputs.debug_with_ssh_key != ''
+    if: github.repository_owner == 'git-for-windows' || github.event.inputs.debug_with_ssh_key != ''
     runs-on: windows-latest
     environment: sync
     steps:
@@ -25,23 +25,21 @@ jobs:
         with:
           persist-credentials: true
           token: ${{ secrets.PUSH_TOKEN }}
-      - name: clone build-extra
-        uses: actions/checkout@v3
-        with:
-          path: usr\\src\\build-extra
-          ref: main
-          repository: git-for-windows/build-extra
-      - name: please sync --only64-bit
-        shell: bash
-        run: sh -x usr/src/build-extra/please.sh sync --force --only-64-bit
-      - name: use git-sdk-64's Bash
-        run: "usr\\bin\\bash.exe -lc 'cygpath -aw /usr/bin >>$GITHUB_PATH && cygpath -aw /mingw64/bin >>$GITHUB_PATH'"
-      - name: commit & push 64-bit SDK
+      - name: Update all Pacman packages
+        shell: pwsh
+        run: |
+          & .\update-via-pacman.ps1
+      - name: use git-sdk-64's Bash and git.exe
+        run: "usr\\bin\\bash.exe -lc 'cygpath -aw /usr/bin >>$GITHUB_PATH && cygpath -aw /cmd >>$GITHUB_PATH'"
+      - name: commit & push SDK
         shell: bash
         run: |
           set -x &&
-          sh -x /usr/src/build-extra/commit-msys2.sh commit &&
-          git -C / push origin ${{ github.ref }}
+          sh -x .github/commit-sdk.sh commit &&
+          git push origin ${{ github.ref }}
+      - name: use MSYS2 for tmate
+        if: failure() && github.event.inputs.debug_with_ssh_key != ''
+        run: "usr\\bin\\bash.exe -lc 'cygpath -aw /c/msys64/usr/bin >>$GITHUB_PATH'"
       - name: Debug using tmate
         if: failure() && github.event.inputs.debug_with_ssh_key != ''
         shell: bash

--- a/update-via-pacman.ps1
+++ b/update-via-pacman.ps1
@@ -1,0 +1,146 @@
+# This script updates a Git for Windows SDK via Pacman.
+#
+# Its primary use is to update the `git-sdk-64` repository at
+# https://github.com/git-for-windows/git-sdk-64, via its `sync`
+# workflow.
+#
+# It can also be run locally. By default, PowerShell does not allow to run
+# scripts. This can be temporarily allowed via
+#
+# Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process
+
+Set-PSDebug -Trace 1
+
+function die {
+  Param(
+    [Parameter(Mandatory=$true,Position=0)] [String]$Message
+  )
+  [Console]::Error.WriteLine($Message)
+  exit 1
+}
+
+# switch to the directory containing this script
+Set-Location $PSScriptRoot
+if (!$?) { die "Could not switch directory to $PSScriptRoot" }
+
+$env:PATH = "$(Get-Location)\usr\bin;" + $env:PATH
+
+# Set to MSYS mode
+$env:MSYSTEM = "MSYS"
+$env:MSYS2_PATH_TYPE = "minimal"
+
+# Create /var/log/ so that pacman.log is written
+if (!(Test-Path var\log -PathType Container)) {
+  New-Item -ItemType Directory -Path var\log -Force
+}
+
+echo "Run Pacman (First Pass)"
+bash -lc "pacman -Syyu --overwrite=\* --noconfirm"
+if (!$?) { exit 1 }
+
+# Ensure that the Git for Windows keyring is registered
+bash -lc @"
+  set -x
+  pacman-key --list-keys BB3AA74136C569BB >/dev/null ||
+  pacman-key --populate git-for-windows
+"@
+if (!$?) { die "Could not re-populate git-for-windows-keyring" }
+
+# If Pacman updated "core" packages, e.g. the MSYS2 runtime, it stops
+# (because Pacman itself depends on the MSYS2 runtime, and continuing would
+# result in crashes or hangs). In such a case, we simply need to upgrade
+# *again*.
+#
+# To detect that, we look at Pacman's log and search for the needle
+#
+# 	[PACMAN] starting <upgrade-type> system upgrade
+#
+# If the last such line has the upgrade type `full`, we're fine, and do not
+# need to run Pacman again. Otherwise we will have to run it again, letting
+# it upgrade the non-core packages.
+
+$type=(
+  Get-Content -Tail 512 var\log\pacman.log |
+  Select-String -AllMatches -Pattern "\[PACMAN\] starting .* system upgrade" |
+  Select -Last 1
+)
+if ($type -Match "full system upgrade") {
+  echo "No second pass needed"
+} else {
+  echo "Run Pacman again (Second Pass) to upgrade the remaining (non-core) packages"
+  bash -lc "pacman -Su --overwrite=\* --noconfirm"
+  if (!$?) { exit 1 }
+
+  # Ensure that the Git for Windows keyring is registered
+  bash -lc @"
+    set -x
+    pacman-key --list-keys BB3AA74136C569BB >/dev/null ||
+    pacman-key --populate git-for-windows
+"@
+  if (!$?) { die "Could not re-populate git-for-windows-keyring" }
+}
+
+# A ruby upgrade (or something else) may require a re-install of the
+# `asciidoctor` gem. We only do this for the 64-bit SDK, though, as we require
+# asciidoctor only when building Git, whose 32-bit packages are cross-compiled
+# in from 64-bit.
+if (Test-Path var/lib/pacman/local/mingw-w64-*-asciidoctor-extensions-[0-9]* -PathType Container) {
+  bash -lc @'
+    set -x
+    for d in clangarm64 mingw64 mingw32
+    do
+      test -x /$d/bin/ruby.exe || continue
+      export PATH=/$d/bin:$PATH
+      test -n \"$(gem list --local | grep \"^asciidoctor \")\" ||
+      gem install asciidoctor || exit
+    done
+'@
+	if (!$?) { die "Could not re-install asciidoctor" }
+}
+
+# Pacman sometimes writes `.pacnew` files; We want to rename them and let
+# the post-install script of the `git-extra` package edit them.
+$latestSystemUpgrade = (
+  Get-Content -Tail 512 var\log\pacman.log |
+  Select-String -AllMatches -Pattern "\[PACMAN\] starting .* system upgrade" |
+  Select -Last 1
+)
+$pacnew = (
+  Get-Content -Tail (512-$latestSystemUpgrade.LineNumber) var\log\pacman.log |
+  Select-String -AllMatches -Pattern "\.pacnew" |
+  ForEach-Object -Process {
+    if ($_.Line -Match "warning:.*installed as /(.*)\.pacnew$") { $Matches[1] }
+  }
+)
+if ($pacnew.Length -gt 0) {
+  $pacnew | ForEach-Object -Process {
+    $newName = $_ -Replace '.*/', ''
+    $path = $_ -Replace '/', '\'
+    $pacnewPath = $path + ".pacnew"
+    if (Test-Path $pacnewPath -PathType Leaf) {
+      if ($newName -eq "pacman.conf") {
+        $ignorePkg = (
+          Get-Content $path |
+          Select-String -Pattern "^IgnorePkg *="
+        )
+        if ($ignorePkg.length -eq 1) {
+          $content = Get-Content $pacnewPath
+          $line = $content | Select-String -Pattern "^ *#? *IgnorePkg *="
+          $content[$line.LineNumber] = $ignorePkg[0]
+          $content -join "`n" | Out-File -NoNewLine -FilePath $pacnewPath -Encoding ascii
+        }
+      }
+
+      Remove-Item -Path $path
+      Rename-Item -Path $pacnewPath -NewName $newName -Force
+    }
+  }
+  bash -lc @"
+    set -x &&
+    . /var/lib/pacman/local/mingw-w64-*-git-extra-[0-9]*/install 2>/dev/null &&
+    post_upgrade
+"@
+}
+
+# Wrapping up: re-install mingw-w64-git-extra
+bash -lc "pacman -S --overwrite=\* --noconfirm mingw-w64-x86_64-git-extra"


### PR DESCRIPTION
It is a bit heavy-handed to clone the entire `build-extra` repository just to perform two tasks, i.e. updating via Pacman and then committing the result.

In the sibling repository `git-sdk-arm64` we already had to decouple the `sync` workflow from `please.sh sync` (because the latter's assumptions could not be fulfilled), and we can adapt that work slightly and integrate it into this here repository.

This commit copy/edits files from 17723bad53b5 (ci: avoid cloning `build-extra`, 2023-01-25) in
https://github.com/git-for-windows/git-sdk-arm64, partially addressing https://github.com/git-for-windows/git/issues/4234