### PR TITLE
Fix `unzip` and `stat` in minimal sdk

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -141,3 +141,7 @@ jobs:
 
           gcc -Wall -g -O2 -shared -o sample.dll dll.c || exit 1
           ls -la
+
+          # stat works
+          test "stat is /usr/bin/stat" = "$(type stat)" || exit 1
+          stat /usr/bin/stat.exe || exit 1

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 env:
   LC_CTYPE: C.UTF-8
@@ -14,7 +15,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: clone git-sdk-64
-        run: git clone --bare --depth=1 --filter=blob:none --single-branch -b ${{github.ref_name}} https://github.com/${{github.repository}}
+        run: |
+          git init --bare git-sdk-64.git &&
+          git --git-dir=git-sdk-64.git remote add origin https://github.com/${{github.repository}} &&
+          git --git-dir=git-sdk-64.git config remote.origin.promisor true &&
+          git --git-dir=git-sdk-64.git config remote.origin.partialCloneFilter blob:none &&
+          git --git-dir=git-sdk-64.git fetch --depth=1 origin ${{github.sha}} &&
+          git --git-dir=git-sdk-64.git update-ref --no-deref HEAD ${{github.sha}}
       - name: clone build-extra
         run: git clone --depth=1 --single-branch -b main https://github.com/git-for-windows/build-extra
       - name: build git-sdk-64-minimal-sdk

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -139,5 +139,5 @@ jobs:
           }
           EOF
 
-          gcc -Wall -g -O2 -shared -o sample.dll dll.c
+          gcc -Wall -g -O2 -shared -o sample.dll dll.c || exit 1
           ls -la

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -39,12 +39,12 @@ jobs:
           minimal-sdk/init.sh
       - name: compress artifact
         shell: bash
-        run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | xz -9 >git-sdk-64-minimal.tar.xz
+        run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | gzip -1 >git-sdk-64-minimal.tar.gz
       - name: upload minimal-sdk artifact
         uses: actions/upload-artifact@v3
         with:
           name: minimal-sdk
-          path: git-sdk-64-minimal.tar.xz
+          path: git-sdk-64-minimal.tar.gz
       - name: clone git.git's `master`
         run: git clone --depth=1 --branch master https://github.com/git/git ..\git
       - name: build current `master` of git.git
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p minimal-sdk &&
-          tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz &&
+          tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
           minimal-sdk/init.sh
       - name: download git artifacts
         uses: actions/download-artifact@v3
@@ -125,7 +125,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p minimal-sdk &&
-          tar -C minimal-sdk -xJf git-sdk-64-minimal.tar.xz &&
+          tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
           minimal-sdk/init.sh
       - name: run some tests
         shell: bash

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -145,3 +145,15 @@ jobs:
           # stat works
           test "stat is /usr/bin/stat" = "$(type stat)" || exit 1
           stat /usr/bin/stat.exe || exit 1
+
+          # unzip works
+          test "unzip is /usr/bin/unzip" = "$(type unzip)" || exit 1
+          git init unzip-test &&
+          echo TEST >unzip-test/README &&
+          git -C unzip-test add -A &&
+          git -C unzip-test -c user.name=A -c user.email=b@c.d commit -m 'Testing, testing...' &&
+          git --git-dir=unzip-test/.git archive -o test.zip HEAD &&
+          unzip -v test.zip >unzip-test.out &&
+          cat unzip-test.out &&
+          test "grep is /usr/bin/grep" = "$(type grep)" || exit 1
+          grep README unzip-test.out

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -126,7 +126,11 @@ jobs:
           PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
         run: |
           set -x
+
+          # cygpath works
           test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
+
+          # comes with GCC and can compile a DLL
           test "$(type -p gcc)" = "/mingw64/bin/gcc" || exit 1
           cat >dll.c <<-\EOF &&
           __attribute__((dllexport)) int increment(int i)

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -257,6 +257,7 @@
 /usr/bin/head.exe
 /usr/bin/rmdir.exe
 /usr/bin/setfacl.exe
+/usr/bin/stat.exe
 /usr/bin/sleep.exe
 /usr/bin/tail.exe
 /usr/bin/tar.exe

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -266,5 +266,6 @@
 /usr/bin/tput.exe
 /usr/bin/true.exe
 /usr/bin/unzip.exe
+/usr/bin/msys-bz2-[0-9]*.dll
 /usr/bin/xargs.exe
 /usr/bin/zipinfo.exe


### PR DESCRIPTION
While working on fixing the [Coverity builds](https://dev.azure.com/Git-for-Windows/git/_build/index?definitionId=35&_a=completed), I switched them to use a slightly extended version of the minimal SDK.

And I could not fail to notice that `stat.exe` and `unzip.exe` were missing and broken, respectively. This here PR fixes that.

Note: To support the Coverity build, I had to include `lzma.exe`, too, but I do not want to include that in the default minimal SDK unless really necessary. And I don't think that it is necessary: we can easily switch to compressing with `gzip.exe`, according to [this documentation that unfortunately requires Sign In, they must really hide sensitive information in the mere instructions... tsk, tsk](https://scan.coverity.com/download): "Create a compress tar archive of the results (gzip, zip, lzma, xz or bz2)".

But for now, let's focus on `ci-artifacts` and the minimal SDK.