### PR TITLE
ci-artifacts: do build with DEVELOPER=1

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -55,7 +55,7 @@ jobs:
           set -x
           test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
           test "$(type -p gcc)" = "/mingw64/bin/gcc" || exit 1
-          make -C ../git NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
+          make -C ../git DEVELOPER=1 NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
       - name: compress git artifacts
         shell: bash
         run: tar -C .. -czf git-artifacts.tar.gz --exclude '*.a' --exclude '*.o' --exclude .git --exclude .depend git


### PR DESCRIPTION
A recent MSYS2 update included an upgrade to GCC v14.1 which is a lot stricter than the previous version, leading to build errors when building Git under `DEVELOPER=1`. One symptom is:

```
 In file included from compat/regex/regex.c:72:
  compat/regex/regex_internal.c: In function 'create_ci_newstate':
  Error: compat/regex/regex_internal.c:1631:48: 'calloc' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
   1631 |   newstate = (re_dfastate_t *) calloc (sizeof (re_dfastate_t), 1);
        |                                                ^~~~~~~~~~~~~
  compat/regex/regex_internal.c:1631:48: note: earlier argument should specify number of elements, later size of each element

This breaks all of Git's CI builds because the
`setup-git-for-windows-sdk` GitHub Action looks for the latest successful `ci-artifacts` run (which did not build with `DEVELOPER=1`), uses the corresponding minimal SDK, and then builds with `DEVELOPER=1` and fails.
```

Let's make `ci-artifacts` more stringent by building with `DEVELOPER=1` so that it does not succeed building Git when Git's own CI would fail at the same task with the same minimal SDK revision.