### PR TITLE
minimal-sdk: support compiling `clar.c`

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -149,6 +149,13 @@ jobs:
           gcc -Wall -g -O2 -shared -o sample.dll dll.c || exit 1
           ls -la
 
+          # #include <shellapi.h> works (needed by clar-test)
+          cat >shellapi-test.c <<-\EOF &&
+          #include <shellapi.h>
+          EOF
+
+          gcc -Wall -g -O2 -c -o shellapi-test.o shellapi-test.c || exit 1
+
           # stat works
           test "stat is /usr/bin/stat" = "$(type stat)" || exit 1
           stat /usr/bin/stat.exe || exit 1

--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -83,6 +83,7 @@
 !/mingw64/include/tuner*
 !/mingw64/include/wm*
 !/mingw64/include/x*
+/mingw64/include/shellapi.h
 /mingw64/lib/*.o
 /mingw64/lib/libadvapi32*
 /mingw64/lib/libbrotli*


### PR DESCRIPTION
In an upcoming contribution, the upstream Git project will want to use https://github.com/clar-test/clar, a powerful C-based test framework. This framework requires the `shellapi.h` header, which we hereby support in the minimal Git for Windows SDK used in CI builds.