### PR TITLE
ci: publish the minimal SDK in a continuous release

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -28,15 +28,7 @@ jobs:
         shell: bash
         run: |
           sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git minimal-sdk &&
-          cat <<-\EOF >minimal-sdk/init.sh &&
-          echo MSYSTEM=MINGW64 >>$GITHUB_ENV &&
-          cd "$(dirname "$0")" &&
-          cygpath -aw usr/bin/core_perl >>$GITHUB_PATH &&
-          cygpath -aw usr/bin >>$GITHUB_PATH &&
-          cygpath -aw mingw64/bin >>$GITHUB_PATH ||
-          exit 1
-          EOF
-          minimal-sdk/init.sh
+          cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: compress artifact
         shell: bash
         run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | gzip -1 >git-sdk-64-minimal.tar.gz
@@ -49,10 +41,9 @@ jobs:
         run: git clone --depth=1 --branch master https://github.com/git/git ..\git
       - name: build current `master` of git.git
         shell: bash
-        env:
-          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
         run: |
           set -x
+          . /etc/profile
           test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
           test "$(type -p gcc)" = "/mingw64/bin/gcc" || exit 1
           make -C ../git DEVELOPER=1 NO_PERL=1 SKIP_DASHED_BUILT_INS=YesPlease -j8 all strip
@@ -82,7 +73,7 @@ jobs:
         run: |
           mkdir -p minimal-sdk &&
           tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
-          minimal-sdk/init.sh
+          cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: download git artifacts
         uses: actions/download-artifact@v4
         with:
@@ -95,6 +86,7 @@ jobs:
         shell: bash
         run: |
           set -x
+          . /etc/profile
           test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1
           cd ../git/t &&
           make T="$(ls -S t[0-9]*.sh | awk '!((NR+${{matrix.nr}})%17)' | tr '\n' \ )" prove || {
@@ -108,7 +100,6 @@ jobs:
             exit 1
           }
         env:
-          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;${{github.workspace}}\minimal-sdk\usr\bin\core_perl;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
           GIT_TEST_OPTS: --verbose-log -x --no-chain-lint
           GIT_PROVE_OPTS: --timer --jobs 8
           NO_SVN_TESTS: 1
@@ -126,13 +117,12 @@ jobs:
         run: |
           mkdir -p minimal-sdk &&
           tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
-          minimal-sdk/init.sh
+          cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: run some tests
         shell: bash
-        env:
-          PATH: ${{github.workspace}}\minimal-sdk\mingw64\bin;${{github.workspace}}\minimal-sdk\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\system32\wbem
         run: |
           set -x
+          . /etc/profile
 
           # cygpath works
           test "$(cygpath -aw /)" = "${{github.workspace}}\minimal-sdk" || exit 1

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+# For the continuous `ci-artifacts` release
+permissions:
+  contents: write
+
 env:
   LC_CTYPE: C.UTF-8
 
@@ -154,3 +158,76 @@ jobs:
           cat unzip-test.out &&
           test "grep is /usr/bin/grep" = "$(type grep)" || exit 1
           grep README unzip-test.out
+  publish-release-assets:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [test-minimal-sdk, assorted-validations]
+    steps:
+      - name: download minimal-sdk artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: minimal-sdk
+          path: ${{github.workspace}}
+      - name: publish release asset
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const req = { owner: context.repo.owner, repo: context.repo.repo }
+            // find or create the GitHub release named `ci-artifacts`
+            const release = await (async () => {
+              try {
+                return await github.rest.repos.getReleaseByTag({ ...req, tag: 'ci-artifacts' });
+              } catch (e) {
+                if (e.status === 404) {
+                  // create the `ci-artifacts` GitHub release based on the current revision
+                  const workflowRunsURL = `${context.serverUrl}/${
+                    process.env.GITHUB_WORKFLOW_REF.replace(/\/\.github\/workflows\/([^@]+).*/, '/actions/workflows/$1')
+                  }`
+                  return await github.rest.repos.createRelease({
+                    ... req,
+                    tag_name: 'ci-artifacts',
+                    body: `Continuous release of \`ci-artifacts\`
+
+            This release is automatically updated by the [ci-artifacts](${workflowRunsURL}) workflow.
+
+            For technical reasons, allow up to a minute for release assets to be missing while they are updated.`,
+                  });
+                }
+                throw e;
+              }
+            })()
+
+            const fs = require('fs')
+            for (const fileName of ['git-sdk-x86_64-minimal.tar.gz']) {
+              console.log(`Uploading ${fileName}`)
+              const uploadReq = {
+                ...req,
+                release_id: release.data.id,
+                name: fileName,
+                headers: {
+                  'content-length': (await fs.promises.stat(fileName)).size,
+                },
+                data: fs.createReadStream(fileName),
+              }
+
+              // if the asset does not yet exist, simply upload it
+              const originalAsset = release.data.assets.filter(asset => asset.name === fileName).pop()
+              if (!originalAsset) {
+                const asset =  await github.rest.repos.uploadReleaseAsset(uploadReq)
+                console.log(`Uploaded to ${asset.data.browser_download_url}`)
+                continue
+              }
+
+              // otherwise upload it using a temporary file name,
+              // then delete the old asset
+              // and then rename the new asset;
+              // this way, the asset is not missing for a long time
+              const asset = await github.rest.repos.uploadReleaseAsset({ ...uploadReq, name: `tmp.${fileName}` })
+              await github.rest.repos.deleteReleaseAsset({ ...req, asset_id: originalAsset.id })
+              const updatedAsset =  await github.rest.repos.updateReleaseAsset({...req,
+                asset_id: asset.data.id,
+                name: fileName,
+                label: fileName,
+              })
+              console.log(`Updated ${updatedAsset.data.browser_download_url}`)
+            }

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -31,12 +31,12 @@ jobs:
           cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: compress artifact
         shell: bash
-        run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | gzip -1 >git-sdk-64-minimal.tar.gz
+        run: (cd minimal-sdk && tar cvf - * .[0-9A-Za-z]*) | gzip -1 >git-sdk-x86_64-minimal.tar.gz
       - name: upload minimal-sdk artifact
         uses: actions/upload-artifact@v4
         with:
           name: minimal-sdk
-          path: git-sdk-64-minimal.tar.gz
+          path: git-sdk-x86_64-minimal.tar.gz
       - name: clone git.git's `master`
         run: git clone --depth=1 --branch master https://github.com/git/git ..\git
       - name: build current `master` of git.git
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p minimal-sdk &&
-          tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
+          tar -C minimal-sdk -xzf git-sdk-x86_64-minimal.tar.gz &&
           cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: download git artifacts
         uses: actions/download-artifact@v4
@@ -116,7 +116,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p minimal-sdk &&
-          tar -C minimal-sdk -xzf git-sdk-64-minimal.tar.gz &&
+          tar -C minimal-sdk -xzf git-sdk-x86_64-minimal.tar.gz &&
           cygpath -aw minimal-sdk/usr/bin >>$GITHUB_PATH
       - name: run some tests
         shell: bash

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -59,6 +59,24 @@ jobs:
         with:
           name: git-artifacts
           path: git-artifacts.tar.gz
+      - name: create zip and 7z SFX variants of the minimal SDK
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        shell: bash
+        run: |
+          for path in mingw64/bin/7z.exe mingw64/bin/7z.dll mingw64/lib/7zip/7zCon.sfx
+          do
+            git --git-dir=git-sdk-64.git show HEAD:$path >${path##*/}
+          done &&
+          mkdir minimal-sdk-extra &&
+          (cd minimal-sdk && ../7z.exe a -mmt=on -mx9 ../minimal-sdk-extra/git-sdk-x86_64-minimal.zip * .?*) &&
+          (cd minimal-sdk && ../7z.exe a -t7z -mmt=on -m0=lzma -mqs -mlc=8 -mx=9 -md=256M -mfb=273 -ms=256M -sfx../7zCon.sfx \
+            ../minimal-sdk-extra/git-sdk-x86_64-minimal.7z.exe * .?*)
+      - name: upload minimal-sdk-extra artifacts
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: minimal-sdk-extra
+          path: minimal-sdk-extra
   test-minimal-sdk:
     runs-on: windows-latest
     needs: [minimal-sdk-artifact]
@@ -168,6 +186,11 @@ jobs:
         with:
           name: minimal-sdk
           path: ${{github.workspace}}
+      - name: download minimal-sdk artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: minimal-sdk-extra
+          path: ${{github.workspace}}
       - name: publish release asset
         uses: actions/github-script@v7
         with:
@@ -198,7 +221,11 @@ jobs:
             })()
 
             const fs = require('fs')
-            for (const fileName of ['git-sdk-x86_64-minimal.tar.gz']) {
+            for (const fileName of [
+              'git-sdk-x86_64-minimal.tar.gz',
+              'git-sdk-x86_64-minimal.zip',
+              'git-sdk-x86_64-minimal.7z.exe',
+            ]) {
               console.log(`Uploading ${fileName}`)
               const uploadReq = {
                 ...req,

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -231,3 +231,9 @@ jobs:
               })
               console.log(`Updated ${updatedAsset.data.browser_download_url}`)
             }
+
+            await github.rest.git.updateRef({
+              ...req,
+              ref: 'tags/ci-artifacts',
+              sha: process.env.GITHUB_SHA,
+            })


### PR DESCRIPTION
Currently, when asking the [`setup-git-for-windows-sdk` Action](https://github.com/git-for-windows/setup-git-for-windows-sdk/) for the minimal SDK, it first looks at the latest successful `ci-artifacts` run to determine the commit, and then performs a shallow, partial & sparse checkout of the `git-sdk-64` repository at that commit.

This is relatively slow, taking typically something around 25 seconds for the actual clone, compared to typically around 3 seconds to restore it from a cached version. Therefore, the Action tries to cache it, even if it sometimes adds quite an overhead (for example, [here](https://github.com/git-for-windows/git/actions/runs/10838555769/job/30077050246#step:3:1) _something_ spent 2 minutes after the cache was saved before the workflow was allowed to continue).

Not only is this taking quite some time, diminishing the developer experience, but it is also unnecessary, seeing as the `ci-artifacts` run already provides the minimal SDK in a ready-to-use form and uploads it as a workflow artifact.

So why not use that workflow artifact? A couple of reasons:

- It would appear as if workflow artifacts are somehow compressed as zip archives on the fly when trying to download them manually,
- While not possible at the time `setup-for-windows-sdk` was designed, [it now seems possible](https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories) to use `actions/download-artifact` to download from other repositories, but:
- Workflow run artifacts obey a limited retention policy, which is undesirable here, and finally:
- You can only download workflow artifacts when authenticated, while clones can be performed anonymously; There are likely use cases where the minimal SDK is needed outside of GitHub Actions (for example in other CI systems).

I once looked into publishing the minimal SDK continuously, first considering [GitHub Packages](https://github.com/features/packages). But they have [rather strict retention rules](https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package#package-deletion-and-restoration-support-on-github) and we definitely do not need to retain anything but the latest working minimal-sdk artifact. (And I don't want to waste resources unnecessarily, even if someone else pays for them.)

Then I had looked into uploading that artifact to Azure Blobs, but [had to pull the plug in one big hurry](https://github.com/git-for-windows/git-sdk-64/commit/e51b79eef9230f4eb4a89719030b26206a33f947) because it threatened to blow my Azure budget.

So eventually I gave up on that plan and instead fell back to the "partial, shallow, sparse clone & then cache" strategy, which is in place to this day.

However, people who are more creative than I am figured out ways to publish artifacts continuously. I just had not found those solutions yet at the time. In the MSYS2 project, for example, they have a `srcinfo` artifact that is updated continuously, and initially they used [`eine/tip`](https://github.com/eine/tip?tab=readme-ov-file) to publish it in a GitHub release that is kept up to date by replacing the assets as new revisions come in. Nowadays they use the same strategy, albeit manually via [`gh release upload --clobber`](https://cli.github.com/manual/gh_release_upload#options).

This here PR uses a slight variation of the same strategy: Since `--clobber` basically [deletes](https://github.com/cli/cli/blob/v2.56.0/pkg/cmd/release/shared/upload.go#L135) the asset before [uploading a new version](https://github.com/cli/cli/blob/v2.56.0/pkg/cmd/release/shared/upload.go#L141), there is a time window where the asset is not available. Since the `.tar.gz` file is around 95MB, uploading it can take a while, in particular given the vagaries of any network operation. For that reason, in this PR the upload is done to a temporary name, then the old asset is deleted, and finally the new asset is renamed to the old name. This does not avoid the window of a missing asset altogether, but at least it makes it a lot smaller.

Finally, I took this opportunity to generate and publish `.zip` and `.7z.exe` variants, the latter being a self-extracting 7-Zip archive that does not require any special tools to extract. Granted, since [a native BSD tar is available in `C:\Windows\system32\tar.exe` on pretty much any non-ancient Windows version](https://devblogs.microsoft.com/commandline/tar-and-curl-come-to-windows/), and that `tar.exe` can extract both `.tar.gz` and `.zip` archives without problems, that seems to be lesser of an issue. But still, there's things like [Windows Nano Server](https://hub.docker.com/r/microsoft/windows-nanoserver) that may not have that BSD tar.

tl;dr with this PR, the `ci-artifacts` workflow runs not only verify that the minimal SDK is able to compile a working `git.exe`, but then also publishes the minimal SDK in various variants in a `git-sdk-64` GitHub release called `ci-artifacts` whose tag will point to the corresponding commit.