### PR TITLE
minimal-sdk: accommodate for gettext v0.23.*

### DIFF
--- a/.sparse/minimal-sdk
+++ b/.sparse/minimal-sdk
@@ -39,6 +39,7 @@
 # gettext (msgfmt)
 /mingw64/bin/msgfmt.exe
 /mingw64/bin/libgettext*.dll
+/mingw64/bin/libtextstyle-*[0-9].dll
 
 # Tcl (to emulate msgfmt, *somewhere*)
 /mingw64/bin/tclsh.exe


### PR DESCRIPTION
Since the update of `mingw-w64-gettext-runtime` (0.22.5-2 -> 0.23.1-1), the `ci-artifacts` workflow is failing to build Git (see e.g. https://github.com/git-for-windows/git-sdk-64/actions/runs/12649348500/job/35245565295#step:8:523):

```
      [...]
      MSGFMT    po/bg.msg application-specific initialization failed: Can't find a usable init.tcl in the following directories:
      D:/a/git-sdk-64/git-sdk-64/minimal-sdk/mingw64/lib/tcl8.6 D:/a/git-sdk-64/git-sdk-64/minimal-sdk/mingw64/lib/tcl8.6 D:/a/git-sdk-64/git-sdk-64/minimal-sdk/lib/tcl8.6 D:/a/git-sdk-64/git-sdk-64/minimal-sdk/mingw64/library D:/a/git-sdk-64/git-sdk-64/minimal-sdk/library D:/a/git-sdk-64/git-sdk-64/minimal-sdk/tcl8.6.13/library D:/a/git-sdk-64/git-sdk-64/tcl8.6.13/library

  This probably means that Tcl wasn't installed properly.
```

The message about Tcl not being installed properly is a red herring: While this _is_ true, the actual fall-back to the real `msgfmt.exe` from the actual `gettext` package _should_ work.

As of v0.23, though, that `msgfmt.exe` program now depends on a newly-introduced library, gettext-libtextstyle. So let's include that in minimal SDK's sparse checkout, too.