### PR TITLE
makepkg-git-i686: accommodate for gettext v0.23.*

### DIFF
--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -31,6 +31,7 @@
 /mingw32/bin/libintl-*.dll
 /mingw32/bin/libgettext*.dll
 /mingw32/bin/libiconv-*.dll
+/mingw32/bin/libtextstyle-*[0-9].dll
 
 # 32-bit Tcl (to emulate msgfmt, *somewhere*)
 /mingw32/bin/tclsh.exe


### PR DESCRIPTION
As of v0.23, the `msgfmt.exe` program depends on a newly-introduced library, gettext-libtextstyle. In https://github.com/git-for-windows/git-sdk-64/pull/90, we included that in minimal SDK's sparse checkout, too.

But we forgot to update the `makepkg-git` sparse definition for building the i686 variant of `mingw-w64-git`. This did not cause problems during the v2.48.0-rc phase so far because the `git-artifacts` workflow builds the i686 variant in the i686 Git SDK.

However, the Azure Pipeline that builds the snapshots (and which I haven't found time to migrate to GitHub Actions in the past two years) still used the x86_64 Git SDK to build the i686 variant of `mingw-w64-git`, and there things fell apart.

So let's fix this.

In the long run, we will want to stop building i686 packages in the x86_64 Git SDK altogether.