### PR TITLE
makepkg-git: accommodate for Ruby v3.4.0

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -81,6 +81,7 @@
 /mingw64/lib/ruby/*/x64-mingw32/enc/encdb.so
 /mingw64/lib/ruby/*/x64-mingw32/enc/windows_1252.so
 /mingw64/lib/ruby/*/optparse.rb
+/mingw64/lib/ruby/*/strscan/strscan.rb
 /mingw64/lib/ruby/*/x64-mingw32/strscan.so
 /mingw64/lib/ruby/*/pathname.rb
 /mingw64/lib/ruby/*/x64-mingw32/pathname.so

--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -142,6 +142,7 @@
 /mingw32/lib/ruby/*/i386-mingw32/enc/windows_1252.so
 /mingw32/lib/ruby/*/optparse.rb
 /mingw32/lib/ruby/*/i386-mingw32/strscan.so
+/mingw32/lib/ruby/*/strscan/strscan.rb
 /mingw32/lib/ruby/*/pathname.rb
 /mingw32/lib/ruby/*/i386-mingw32/pathname.so
 /mingw32/lib/ruby/*/did_you_mean*


### PR DESCRIPTION
In that version, `strscan` not only has a native library but also Ruby code that we need to provide to be able to run `asciidoctor` (which is used to render Git's documentation).