### PR TITLE
makepkg-git-i686: ensure that MINGW_ARCH=mingw32 works

### DIFF
--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -168,3 +168,6 @@
 # For a functional 32-bit `tclsh` so that git-gui can be built
 /mingw32/bin/wish.exe
 /mingw32/lib/tcl8.6/
+
+# To let MINGW_ARCH=mingw32 work
+/etc/msystem.d/


### PR DESCRIPTION
It needs the `/etc/msystem.d/` files... This is the reason why the [recent `git-artifacts` runs in `git-sdk-64`](https://github.com/git-for-windows/git-sdk-64/actions/workflows/git-artifacts.yml) failed.

The underlying root cause is most likely the "filesystem (2025.02.23-1 -> 2025.05.08-1)" upgrade in https://github.com/git-for-windows/git-sdk-64/commit/43e407b9315301b119ff277daecd8bdaab05c2f7.

I [verified in my fork](https://github.com/dscho/git-sdk-64/actions/runs/15275926280) that this commit fixes the issue.