### PR TITLE
ci-artifacts: add .tar.zst and build-installers flavor

### DIFF
--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           cd .. &&
           echo "result=$(pwd)" >>$GITHUB_OUTPUT
-      - name: create zip and 7z SFX variants of the minimal SDK
+      - name: create zip, zstd and 7z SFX variants of the minimal SDK
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         shell: bash
         run: |
@@ -76,6 +76,8 @@ jobs:
             git --git-dir=git-sdk-64.git show HEAD:$path >${path##*/}
           done &&
           mkdir minimal-sdk-extra &&
+          (cd minimal-sdk && /c/Windows/system32/tar.exe --zstd --options=zstd:compression-level=10 \
+            -cf ../minimal-sdk-extra/git-sdk-x86_64-minimal.tar.zst * .[0-9A-Za-z]*) &&
           (cd minimal-sdk && ../7z.exe a -mmt=on -mx9 ../minimal-sdk-extra/git-sdk-x86_64-minimal.zip * .?*) &&
           (cd minimal-sdk && ../7z.exe a -t7z -mmt=on -m0=lzma -mqs -mlc=8 -mx=9 -md=256M -mfb=273 -ms=256M -sfx../7zCon.sfx \
             ../minimal-sdk-extra/git-sdk-x86_64-minimal.7z.exe * .?*)
@@ -141,6 +143,7 @@ jobs:
             const fs = require('fs')
             for (const fileName of [
               'git-sdk-x86_64-minimal.tar.gz',
+              'git-sdk-x86_64-minimal.tar.zst',
               'git-sdk-x86_64-minimal.zip',
               'git-sdk-x86_64-minimal.7z.exe',
             ]) {

--- a/.github/workflows/ci-artifacts.yml
+++ b/.github/workflows/ci-artifacts.yml
@@ -88,6 +88,35 @@ jobs:
           name: minimal-sdk-extra
           path: minimal-sdk-extra
 
+  build-installers-artifact:
+    if: github.event.repository.fork == false && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: windows-latest
+    steps:
+      - name: clone git-sdk-64
+        run: |
+          git init --bare git-sdk-64.git &&
+          git --git-dir=git-sdk-64.git remote add origin https://github.com/${{github.repository}} &&
+          git --git-dir=git-sdk-64.git config remote.origin.promisor true &&
+          git --git-dir=git-sdk-64.git config remote.origin.partialCloneFilter blob:none &&
+          git --git-dir=git-sdk-64.git fetch --depth=1 origin ${{github.sha}} &&
+          git --git-dir=git-sdk-64.git update-ref --no-deref HEAD ${{github.sha}}
+      - name: clone build-extra
+        run: git clone --depth=1 --single-branch -b main https://github.com/git-for-windows/build-extra
+      - name: build git-sdk-64-build-installers
+        shell: bash
+        run: sh -x ./build-extra/please.sh create-sdk-artifact --sdk=git-sdk-64.git build-installers
+      - name: compress artifact
+        shell: bash
+        run: |
+          mkdir build-installers-artifacts &&
+          (cd build-installers && /c/Windows/system32/tar.exe --zstd --options=zstd:compression-level=10 \
+            -cf ../build-installers-artifacts/git-sdk-x86_64-build-installers.tar.zst * .[0-9A-Za-z]*)
+      - name: upload build-installers artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: build-installers
+          path: build-installers-artifacts
+
   test-minimal-sdk:
     needs: minimal-sdk-artifact
     uses: ./.github/workflows/test-ci-artifacts.yml
@@ -99,7 +128,9 @@ jobs:
   publish-release-assets:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: test-minimal-sdk
+    needs:
+      - test-minimal-sdk
+      - build-installers-artifact
     steps:
       - name: download minimal-sdk artifact
         uses: actions/download-artifact@v7
@@ -110,6 +141,11 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: minimal-sdk-extra
+          path: ${{github.workspace}}
+      - name: download build-installers artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: build-installers
           path: ${{github.workspace}}
       - name: publish release asset
         uses: actions/github-script@v8
@@ -146,6 +182,7 @@ jobs:
               'git-sdk-x86_64-minimal.tar.zst',
               'git-sdk-x86_64-minimal.zip',
               'git-sdk-x86_64-minimal.7z.exe',
+              'git-sdk-x86_64-build-installers.tar.zst',
             ]) {
               console.log(`Uploading ${fileName}`)
               const uploadReq = {


### PR DESCRIPTION
This PR extends the `ci-artifacts` workflow to also produce a `.tar.zst` (Zstandard) variant of the minimal SDK release asset, and adds a new parallel job that packages the build-installers flavor of the SDK.

### Commit 1: `.tar.zst` for minimal SDK

Windows' built-in BSD tar (`C:\Windows\system32\tar.exe`) on Server 2025 ships with native zstd support via libzstd (no external binary needed). The `.tar.zst` at zstd level 10 is a third smaller than `.tar.gz` while extracting almost twice as fast:

| Format | Size (MB) | Extract (s) |
|--------|-----------|-------------|
| tar.gz | 90.9 | 10.2 |
| **tar.zst** | **60.7** | **5.8** |
| zip | 79.7 | 5.3 |
| 7z SFX | 37.6 | 26.3 |

The `.tar.gz` is retained for backward compatibility.

### Commit 2: build-installers artifact

A new `build-installers-artifact` job runs in parallel with the existing jobs, packaging the build-installers SDK flavor (everything needed to build installers, Portable Git, and MinGit). Only `.tar.zst` is offered for this new artifact since there are no legacy consumers:

| Format | Size (MB) | Extract (s) |
|--------|-----------|-------------|
| tar.gz | 308.9 | 29.7 |
| **tar.zst** | **219.0** | **27.5** |

The publish job now waits for both the test suite and the build-installers job before uploading release assets.