### PR TITLE
Adapt to the layout of Ruby v4

### DIFF
--- a/.sparse/makepkg-git
+++ b/.sparse/makepkg-git
@@ -77,7 +77,7 @@
 /mingw64/lib/ruby/gems/*/specifications/asciidoctor-*.gemspec
 /mingw64/lib/ruby/*/tsort.rb
 /mingw64/lib/ruby/*/set.rb
-/mingw64/lib/ruby/*/logger.rb
+/mingw64/lib/ruby/**/*/logger*
 /mingw64/lib/ruby/*/x64-mingw32/enc/encdb.so
 /mingw64/lib/ruby/*/x64-mingw32/enc/windows_1252.so
 /mingw64/lib/ruby/*/optparse.rb
@@ -86,8 +86,7 @@
 /mingw64/lib/ruby/*/pathname.rb
 /mingw64/lib/ruby/*/x64-mingw32/pathname.so
 /mingw64/lib/ruby/*/did_you_mean*
-/mingw64/lib/ruby/*/cgi/util*
-/mingw64/lib/ruby/*/logger*
+/mingw64/lib/ruby/*/cgi/*
 /mingw64/lib/ruby/*/bundled_gems.rb
 /mingw64/lib/ruby/*/syntax_suggest*
 

--- a/.sparse/makepkg-git-i686
+++ b/.sparse/makepkg-git-i686
@@ -138,7 +138,7 @@
 /mingw32/lib/ruby/gems/*/specifications/asciidoctor-*.gemspec
 /mingw32/lib/ruby/*/tsort.rb
 /mingw32/lib/ruby/*/set.rb
-/mingw32/lib/ruby/*/logger.rb
+/mingw32/lib/ruby/**/*/logger*
 /mingw32/lib/ruby/*/i386-mingw32/enc/encdb.so
 /mingw32/lib/ruby/*/i386-mingw32/enc/windows_1252.so
 /mingw32/lib/ruby/*/optparse.rb
@@ -147,8 +147,7 @@
 /mingw32/lib/ruby/*/pathname.rb
 /mingw32/lib/ruby/*/i386-mingw32/pathname.so
 /mingw32/lib/ruby/*/did_you_mean*
-/mingw32/lib/ruby/*/cgi/util*
-/mingw32/lib/ruby/*/logger*
+/mingw32/lib/ruby/*/cgi/*
 /mingw32/lib/ruby/*/bundled_gems.rb
 /mingw32/lib/ruby/*/syntax_suggest*
 


### PR DESCRIPTION
After https://github.com/msys2/MINGW-packages/pull/30629 (i.e. upgrading from Ruby v3 to Ruby v4), git-sdk-arm64's `git-artifacts` workflow fails, https://github.com/git-for-windows/git-sdk-64/actions/runs/30686436267/job/91347893289#step:9:375

```
    ASCIIDOC ToolsForGit.html
  D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/4.0.0/cgi/util.rb:3:in 'Kernel#require': cannot load such file -- cgi/escape (LoadError)
  Did you mean?  cgi/util
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/4.0.0/cgi/util.rb:3:in '<top (required)>'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/lib/asciidoctor.rb:9:in 'Kernel#require'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/lib/asciidoctor.rb:9:in '<top (required)>'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/bin/asciidoctor:6:in 'Kernel#require'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/gems/4.0.0/gems/asciidoctor-2.0.26/bin/asciidoctor:6:in '<top (required)>'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/4.0.0/rubygems.rb:305:in 'Kernel#load'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/lib/ruby/4.0.0/rubygems.rb:305:in 'Gem.activate_and_load_bin_path'
	from D:/a/git-sdk-64/git-sdk-64/build-installers/mingw64/bin/asciidoctor:36:in '<main>'
make[1]: *** [Makefile:396: ToolsForGit.html] Error 1
```

The reason is a changed file layout of Ruby's gems. Let's adapt to that.